### PR TITLE
ZON-3213 Always disable Push Service

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ zeit.push changes
 1.14.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Always disable push services on send to avoid the risk of re-sending a
+  notification on publish, since information might not be relevant anymore.
 
 
 1.14.0 (2016-05-09)

--- a/src/zeit/push/message.py
+++ b/src/zeit/push/message.py
@@ -17,6 +17,15 @@ class Message(grok.Adapter):
         self.config = {}
 
     def send(self):
+        """Send push notification to external service.
+
+        We *never* want to re-send a push notification on publish, even if the
+        initial notification failed, since the information could be outdated.
+        Therefore we must disable the notification before anything else.
+        Re-sending can be done manually by re-enabling the service.
+
+        """
+        self._disable_message_config()
         notifier = zope.component.getUtility(
             zeit.push.interfaces.IPushNotifier, name=self.type)
         if not self.text:
@@ -25,7 +34,6 @@ class Message(grok.Adapter):
         kw.update(self.config)
         kw.update(self.additional_parameters)
         notifier.send(self.text, self.url, **kw)
-        self._disable_message_config()
 
     def _disable_message_config(self):
         push = zeit.push.interfaces.IPushMessages(self.context)


### PR DESCRIPTION
Im Rahmen von ZON-3213 wurde noch einmal besprochen, dass ein fehlgeschlagener Push zurzeit beim veröffentlichen erneut gesendet wird. Da die Information dann aber bereits veraltet und irrelevant sein kann, sollen Pushes generell nicht wiederholt werden.

Ich habe auf den Branch auch einige Verbesserungen an der Interface Dokumentation eingecheckt.
