### PR TITLE
ZON-3213: Make audience group of Urban Airship configurable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ zeit.push changes
 
 - Update to `zeit.cms >= 2.90`.
 
+- MAINT: Change audience group for Urban Airship to ``subscriptions`` by making
+  it configurable via product config.
+
 
 1.15.4 (2016-09-14)
 -------------------

--- a/src/zeit/push/__init__.py
+++ b/src/zeit/push/__init__.py
@@ -16,6 +16,7 @@ product_config = """\
   parse-channel-breaking Eilmeldung
   parse-channel-news News
   parse-image-pattern 184x84
+  urbanairship-audience-group subscriptions
 </product-config>
 """.format(fixtures=pkg_resources.resource_filename(
     __name__, 'tests/fixtures'))

--- a/src/zeit/push/tests/test_urbanairship.py
+++ b/src/zeit/push/tests/test_urbanairship.py
@@ -96,10 +96,10 @@ class ConnectionTest(zeit.push.testing.TestCase):
         with mock.patch.object(api, 'push') as push:
             api.send('foo', 'any', channels=PARSE_NEWS_CHANNEL)
             self.assertEqual(
-                {'or': [{'tag': 'News'}], 'group': 'device'},
+                {'or': [{'tag': 'News'}], 'group': 'subscriptions'},
                 push.call_args_list[0][0][0].audience)
             self.assertEqual(
-                {'or': [{'tag': 'News'}], 'group': 'device'},
+                {'or': [{'tag': 'News'}], 'group': 'subscriptions'},
                 push.call_args_list[1][0][0].audience)
 
     def test_sends_to_all_devices_if_no_channels_parameter(self):

--- a/src/zeit/push/urbanairship.py
+++ b/src/zeit/push/urbanairship.py
@@ -39,7 +39,7 @@ class Connection(zeit.push.mobile.ConnectionBase):
         if channels:
             audience = {
                 'or': [{'tag': channel} for channel in channels],
-                'group': 'device'
+                'group': self.config['urbanairship-audience-group']
             }
 
         # The expiration datetime must not contain microseconds, therefore we


### PR DESCRIPTION
- had to be changed to `subscriptions`
- to avoid release in case of future changes, we just use a value from product config

Benötigt https://github.com/ZeitOnline/vivi-deployment/pull/13.
