### PR TITLE
ZON-3213: Abort push to Urban Airship if no channel was given

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,9 @@ zeit.push changes
 - MAINT: Change audience group for Urban Airship to ``subscriptions`` by making
   it configurable via product config.
 
+- MAINT: Abort push to Urban Airship and display message in Log if no channel
+  was given to avoid accidental push to *all* devices.
+
 
 1.15.4 (2016-09-14)
 -------------------

--- a/src/zeit/push/tests/test_urbanairship.py
+++ b/src/zeit/push/tests/test_urbanairship.py
@@ -105,14 +105,14 @@ class ConnectionTest(zeit.push.testing.TestCase):
                 {'or': [{'tag': 'News'}], 'group': 'subscriptions'},
                 push.call_args_list[1][0][0].audience)
 
-    def test_raises_AttributeError_if_no_channel_given(self):
+    def test_raises_if_no_channel_given(self):
         api = self.connection()
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(ValueError):
             api.send('Being pushy.', 'http://example.com')
 
-    def test_raises_AttributeError_if_channel_not_in_product_config(self):
+    def test_raises_if_channel_not_in_product_config(self):
         api = self.connection()
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(ValueError):
             api.send('foo', 'any', channels='i-am-not-in-product-config')
 
     def test_sets_expiration_time_in_payload(self):

--- a/src/zeit/push/tests/test_urbanairship.py
+++ b/src/zeit/push/tests/test_urbanairship.py
@@ -52,14 +52,16 @@ class PushTest(unittest.TestCase):
             self.ios_application_key, self.ios_master_secret, 1)
         with mock.patch('urbanairship.push.core.Push.send', send):
             with mock.patch('urbanairship.push.core.PushResponse') as push:
-                api.send('Push', 'http://example.com')
+                api.send('Push', 'http://example.com',
+                         channels=PARSE_NEWS_CHANNEL)
                 self.assertEqual(200, push.call_args[0][0].status_code)
 
     def test_invalid_credentials_should_raise(self):
         api = zeit.push.urbanairship.Connection(
             'invalid', 'invalid', 'invalid', 'invalid', 1)
         with self.assertRaises(zeit.push.interfaces.WebServiceError):
-            api.send('Being pushy.', 'http://example.com')
+            api.send('Being pushy.', 'http://example.com',
+                     channels=PARSE_NEWS_CHANNEL)
 
     def test_server_error_should_raise(self):
         response = mock.Mock()
@@ -73,7 +75,8 @@ class PushTest(unittest.TestCase):
         with mock.patch('requests.sessions.Session.request') as request:
             request.return_value = response
             with self.assertRaises(zeit.push.interfaces.TechnicalError):
-                api.send('Being pushy.', 'http://example.com')
+                api.send('Being pushy.', 'http://example.com',
+                         channels=PARSE_NEWS_CHANNEL)
 
 
 class ConnectionTest(zeit.push.testing.TestCase):
@@ -85,7 +88,7 @@ class ConnectionTest(zeit.push.testing.TestCase):
     def test_pushes_to_android_and_ios(self):
         api = self.connection()
         with mock.patch.object(api, 'push') as push:
-            api.send('foo', 'any')
+            api.send('foo', 'any', channels=PARSE_NEWS_CHANNEL)
             self.assertEqual(
                 ['android'], push.call_args_list[0][0][0].device_types)
             self.assertEqual(
@@ -102,22 +105,15 @@ class ConnectionTest(zeit.push.testing.TestCase):
                 {'or': [{'tag': 'News'}], 'group': 'subscriptions'},
                 push.call_args_list[1][0][0].audience)
 
-    def test_sends_to_all_devices_if_no_channels_parameter(self):
+    def test_raises_AttributeError_if_no_channel_given(self):
         api = self.connection()
-        with mock.patch.object(api, 'push') as push:
-            api.send('foo', 'any')
-            self.assertEqual('all', push.call_args_list[0][0][0].audience)
-            self.assertEqual('all', push.call_args_list[1][0][0].audience)
+        with self.assertRaises(AttributeError):
+            api.send('Being pushy.', 'http://example.com')
 
-    def test_sends_to_all_devices_if_empty_product_config(self):
-        product_config = zope.app.appsetup.product.getProductConfiguration(
-            'zeit.push')
-        product_config['foo'] = ''
+    def test_raises_AttributeError_if_channel_not_in_product_config(self):
         api = self.connection()
-        with mock.patch.object(api, 'push') as push:
-            api.send('foo', 'any', channels='foo')
-            self.assertEqual('all', push.call_args_list[0][0][0].audience)
-            self.assertEqual('all', push.call_args_list[1][0][0].audience)
+        with self.assertRaises(AttributeError):
+            api.send('foo', 'any', channels='i-am-not-in-product-config')
 
     def test_sets_expiration_time_in_payload(self):
         api = self.connection(expire_interval=3600)
@@ -125,7 +121,7 @@ class ConnectionTest(zeit.push.testing.TestCase):
             mock_datetime.now.return_value = (
                 datetime(2014, 07, 1, 10, 15, 7, 38, tzinfo=pytz.UTC))
             with mock.patch.object(api, 'push') as push:
-                api.send('foo', 'any')
+                api.send('foo', 'any', channels=PARSE_NEWS_CHANNEL)
                 self.assertEqual(
                     '2014-07-01T11:15:07',
                     push.call_args_list[0][0][0].options['expiry'])

--- a/src/zeit/push/urbanairship.py
+++ b/src/zeit/push/urbanairship.py
@@ -37,7 +37,7 @@ class Connection(zeit.push.mobile.ConnectionBase):
         # We need channels to define the target audience in order to avoid
         # accidental pushes to *all* devices.
         if not channels:
-            raise AttributeError('No channel given to define target audience.')
+            raise ValueError('No channel given to define target audience.')
 
         audience = {
             'or': [{'tag': channel} for channel in channels],

--- a/src/zeit/push/urbanairship.py
+++ b/src/zeit/push/urbanairship.py
@@ -34,13 +34,15 @@ class Connection(zeit.push.mobile.ConnectionBase):
         data['android']['tag'] = tag
         data['ios']['tag'] = tag
 
-        # If no channel was given, send notification to all users as fallback.
-        audience = 'all'
-        if channels:
-            audience = {
-                'or': [{'tag': channel} for channel in channels],
-                'group': self.config['urbanairship-audience-group']
-            }
+        # We need channels to define the target audience in order to avoid
+        # accidental pushes to *all* devices.
+        if not channels:
+            raise AttributeError('No channel given to define target audience.')
+
+        audience = {
+            'or': [{'tag': channel} for channel in channels],
+            'group': self.config['urbanairship-audience-group']
+        }
 
         # The expiration datetime must not contain microseconds, therefore we
         # cannot use `isoformat`.


### PR DESCRIPTION
Zurzeit ist es möglich, bei Fehlkonfiguration einen Push an _alle_ Nutzer zu schicken. Egal ob News, Eilmeldung oder kein Abo. Mittlerweile halte ich diesen Default für gefährlich und würde lieber abbrechen.

Durch den AttributeError sieht man auch eine Meldung im ILog.
