### PR TITLE
ZON-3278: Refactor test infrastructure to make mock notifiers reusable.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.push changes
 =================
 
-1.16.1 (unreleased)
+1.17.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-3278: Refactor test infrastructure to make mock notifiers reusable.
 
 
 1.16.0 (2016-09-26)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.push',
-    version='1.16.1.dev0',
+    version='1.17.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',


### PR DESCRIPTION
Changes needed in zeit.content.video.
