### PR TITLE
ZON-4006: Split off mobile fields into their own form, so z.c.article can display them separately

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,8 @@ zeit.push changes
 
 - MAINT: Remove obsolete banner control files (wrapper, ios-legacy)
 
+- MAINT: Remove broken/unused ``IPushMessages.date_last_pushed``
+
 
 1.20.2 (2017-05-22)
 -------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,10 +4,14 @@ zeit.push changes
 1.21.0 (unreleased)
 -------------------
 
+- ZON-4006: Split off mobile fields into their own form
+
 - BUG-674: Don't perform push-target-url replacement twice,
   and don't squash non-www.zeit.de URLs
 
 - BUG-621: Log Twitter and Facebook account name to objectlog
+
+- MAINT: Remove obsolete banner control files (wrapper, ios-legacy)
 
 
 1.20.2 (2017-05-22)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 zeit.push changes
 =================
 
-1.20.3 (unreleased)
+1.21.0 (unreleased)
 -------------------
 
 - BUG-674: Don't perform push-target-url replacement twice,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.push',
-    version='1.20.3.dev0',
+    version='1.21.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/push/banner.py
+++ b/src/zeit/push/banner.py
@@ -64,36 +64,7 @@ def homepage_banner():
     return StaticArticlePublisher(config['homepage-banner-uniqueid'])
 
 
-@zope.interface.implementer(zeit.push.interfaces.IPushNotifier)
-def ios_legacy():
-    config = zope.app.appsetup.product.getProductConfiguration('zeit.push')
-    return StaticArticlePublisher(config['ios-legacy-uniqueid'])
-
-
-@zope.interface.implementer(zeit.push.interfaces.IPushNotifier)
-def wrapper_banner():
-    config = zope.app.appsetup.product.getProductConfiguration('zeit.push')
-    return StaticArticlePublisher(config['wrapper-banner-uniqueid'])
-
-
 class HomepageMessage(zeit.push.message.Message):
 
     grok.name('homepage')
     get_text_from = 'short_text'
-
-
-class LegacyIOSMessage(zeit.push.message.Message):
-
-    grok.name('ios-legacy')
-    get_text_from = 'short_text'
-
-
-class WrapperMessage(zeit.push.message.Message):
-
-    grok.name('wrapper')
-    get_text_from = 'short_text'
-
-    @property
-    def url(self):
-        return zeit.push.interfaces.IPushURL(self.context).replace(
-            zeit.cms.interfaces.ID_NAMESPACE, 'http://wrapper.zeit.de/')

--- a/src/zeit/push/browser/banner-retract.pt
+++ b/src/zeit/push/browser/banner-retract.pt
@@ -7,14 +7,6 @@
       tal:attributes="cms:context view/homepage/@@absolute_url"
       i18n:translate="">Retract
     <span i18n:name="target" i18n:translate="">homepage banner</span></li>
-  <li action="retract"
-      tal:attributes="cms:context view/ios_legacy/@@absolute_url"
-      i18n:translate="">Retract
-    <span i18n:name="target" i18n:translate="">iOS legacy</span></li>
-  <li action="retract"
-      tal:attributes="cms:context view/wrapper/@@absolute_url"
-      i18n:translate="">Retract
-    <span i18n:name="target" i18n:translate="">wrapper banner</span></li>
   <li action="close" i18n:translate="">Done</li>
 </ol>
 

--- a/src/zeit/push/browser/banner.py
+++ b/src/zeit/push/browser/banner.py
@@ -13,18 +13,6 @@ class Retract(object):
         return ICMSContent(notifier.uniqueId)
 
     @property
-    def ios_legacy(self):
-        notifier = zope.component.getUtility(
-            zeit.push.interfaces.IPushNotifier, name='ios-legacy')
-        return ICMSContent(notifier.uniqueId)
-
-    @property
-    def wrapper(self):
-        notifier = zope.component.getUtility(
-            zeit.push.interfaces.IPushNotifier, name='wrapper')
-        return ICMSContent(notifier.uniqueId)
-
-    @property
     def banner_matches(self):
         breaking = zeit.content.article.interfaces.IBreakingNews(
             self.context, None)

--- a/src/zeit/push/browser/form.py
+++ b/src/zeit/push/browser/form.py
@@ -1,5 +1,4 @@
 from zeit.cms.i18n import MessageFactory as _
-from zeit.push.interfaces import facebookAccountSource, twitterAccountSource
 import gocept.form.grouped
 import zeit.cms.browser.form
 import zeit.cms.testcontenttype.interfaces
@@ -55,35 +54,6 @@ class SocialBase(zeit.cms.browser.form.CharlimitMixin):
         cloned.required = True
         self.widgets[name].context = cloned
 
-    def applyAccountData(self, object, data):
-        # We cannot use the key ``text``, since the first positional parameter
-        # of IPushNotifier.send() is also called text, which would result in a
-        # TypeError.
-        zeit.push.interfaces.IPushMessages(object).message_config = [
-            {'type': 'facebook',
-             'enabled': data.pop('facebook_main_enabled', False),
-             'override_text': data.pop('facebook_main_text', None),
-             'account': facebookAccountSource(None).MAIN_ACCOUNT},
-            {'type': 'facebook',
-             'enabled': data.pop('facebook_magazin_enabled', False),
-             'override_text': data.pop('facebook_magazin_text', None),
-             'account': facebookAccountSource(None).MAGAZIN_ACCOUNT},
-            {'type': 'facebook',
-             'enabled': data.pop('facebook_campus_enabled', False),
-             'override_text': data.pop('facebook_campus_text', None),
-             'account': facebookAccountSource(None).CAMPUS_ACCOUNT},
-            {'type': 'twitter',
-             'enabled': data.pop('twitter_main_enabled', False),
-             'account': twitterAccountSource(None).MAIN_ACCOUNT},
-            {'type': 'twitter',
-             'enabled': data.pop('twitter_ressort_enabled', False),
-             'account': data.pop('twitter_ressort', None)},
-            {'type': 'mobile',
-             'enabled': data.pop('mobile_enabled', False),
-             'override_text': data.pop('mobile_text', None),
-             'channels': zeit.push.interfaces.CONFIG_CHANNEL_NEWS},
-        ]
-
 
 class SocialAddForm(
         SocialBase, zeit.cms.content.browser.form.CommonMetadataAddForm):
@@ -97,17 +67,7 @@ class SocialAddForm(
         zeit.cms.content.browser.form.CommonMetadataAddForm.field_groups +
         (SocialBase.social_fields,))
 
-    def applyChanges(self, object, data):
-        self.applyAccountData(object, data)
-        return super(SocialAddForm, self).applyChanges(object, data)
-
 
 class SocialEditForm(SocialBase, zeit.cms.browser.form.EditForm):
 
     form_fields = zope.formlib.form.FormFields()
-
-    @zope.formlib.form.action(
-        _('Apply'), condition=zope.formlib.form.haveInputWidgets)
-    def handle_edit_action(self, action, data):
-        self.applyAccountData(self.context, data)
-        super(SocialEditForm, self).handle_edit_action.success(data)

--- a/src/zeit/push/browser/tests/test_banner.py
+++ b/src/zeit/push/browser/tests/test_banner.py
@@ -12,18 +12,16 @@ class RetractBannerTest(zeit.cms.testing.BrowserTestCase):
     def setUp(self):
         super(RetractBannerTest, self).setUp()
         with zeit.cms.testing.site(self.getRootFolder()):
-            for name in ['homepage', 'ios-legacy', 'wrapper']:
-                content = ExampleContentType()
-                self.repository[name] = content
-                notifier = zope.component.getUtility(
-                    zeit.push.interfaces.IPushNotifier, name=name)
-                notifier.uniqueId = content.uniqueId
+            content = ExampleContentType()
+            self.repository['homepage'] = content
+            notifier = zope.component.getUtility(
+                zeit.push.interfaces.IPushNotifier, name='homepage')
+            notifier.uniqueId = content.uniqueId
 
     def tearDown(self):
-        for name in ['homepage', 'ios-legacy', 'wrapper']:
-            notifier = zope.component.getUtility(
-                zeit.push.interfaces.IPushNotifier, name=name)
-            del notifier.uniqueId
+        notifier = zope.component.getUtility(
+            zeit.push.interfaces.IPushNotifier, name='homepage')
+        del notifier.uniqueId
         super(RetractBannerTest, self).tearDown()
 
     def test_renders_url_for_each_banner(self):
@@ -32,6 +30,4 @@ class RetractBannerTest(zeit.cms.testing.BrowserTestCase):
                 'zeit.push.browser.banner.Retract.banner_matches', new=True):
             b.open('http://localhost/++skin++vivi/@@breaking-banner-retract')
         self.assertEllipsis("""\
-            ...cms:context=".../repository/homepage"...
-            ...cms:context=".../repository/ios-legacy"...
-            ...cms:context=".../repository/wrapper"...""", b.contents)
+            ...cms:context=".../repository/homepage"...""", b.contents)

--- a/src/zeit/push/browser/tests/test_form.py
+++ b/src/zeit/push/browser/tests/test_form.py
@@ -143,15 +143,6 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         self.open_form()
         self.assertEqual('facebook', b.getControl('Facebook Main Text').value)
 
-    def test_shows_long_text_as_bbb_for_facebook_override_text(self):
-        article = self.get_article()
-        push = zeit.push.interfaces.IPushMessages(article)
-        push.long_text = 'facebook'
-        self.open_form()
-        b = self.browser
-        self.assertEqual(
-            'facebook', b.getControl('Facebook Main Text').value)
-
     def test_stores_mobile_override_text(self):
         self.open_form()
         b = self.browser

--- a/src/zeit/push/browser/tests/test_form.py
+++ b/src/zeit/push/browser/tests/test_form.py
@@ -48,11 +48,14 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         b.getControl('Apply').click()
         article = self.get_article()
         push = zeit.push.interfaces.IPushMessages(article)
+        # No entries for Facebook Magazin and Campus are created, since we
+        # did not enable those.
+        self.assertEqual(4, len(push.message_config))
         self.assertIn(
             {'type': 'twitter', 'enabled': True, 'account': 'twitter-test'},
             push.message_config)
         self.assertIn(
-            {'type': 'twitter', 'enabled': True,
+            {'type': 'twitter', 'enabled': True, 'variant': 'ressort',
              'account': 'twitter_ressort_wissen'},
             push.message_config)
         self.assertIn(
@@ -77,12 +80,12 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         b.getControl('Apply').click()
         article = self.get_article()
         push = zeit.push.interfaces.IPushMessages(article)
-        self.assertEqual(6, len(push.message_config))
+        self.assertEqual(4, len(push.message_config))
         self.assertIn(
             {'type': 'twitter', 'enabled': False, 'account': 'twitter-test'},
             push.message_config)
         self.assertIn(
-            {'type': 'twitter', 'enabled': False,
+            {'type': 'twitter', 'enabled': False, 'variant': 'ressort',
              'account': 'twitter_ressort_wissen'},
             push.message_config)
         self.assertIn(
@@ -109,7 +112,7 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         article = self.get_article()
         push = zeit.push.interfaces.IPushMessages(article)
         self.assertIn(
-            {'type': 'twitter', 'enabled': True,
+            {'type': 'twitter', 'enabled': True, 'variant': 'ressort',
              'account': 'twitter_ressort_wissen'},
             push.message_config)
 

--- a/src/zeit/push/interfaces.py
+++ b/src/zeit/push/interfaces.py
@@ -119,6 +119,17 @@ class IPushMessages(zope.interface.Interface):
     messages = zope.interface.Attribute(
         'List of IMessage objects, one for each enabled message_config entry')
 
+    def get(**query):
+        """Returns the first entry in message_config that matches the given
+        query key/values.
+        """
+
+    def set(query, **values):
+        """Updates the first entry in message_config that matches the given
+        query key/values with the given values. If none is found, a new entry
+        is appended, combining query and values.
+        """
+
 
 CONFIG_CHANNEL_NEWS = 'channel-news'
 CONFIG_CHANNEL_BREAKING = 'channel-breaking'

--- a/src/zeit/push/interfaces.py
+++ b/src/zeit/push/interfaces.py
@@ -93,10 +93,6 @@ class IPushMessages(zope.interface.Interface):
     date_last_pushed = zope.schema.Datetime(
         title=_('Last push'), required=False, readonly=True)
 
-    # BBB deprecated, Facebook texts are now stored per account in
-    # message_config.
-    long_text = zope.schema.Text(
-        title=_('Long push text'), required=False)
     short_text = zope.schema.TextLine(
         title=_('Short push text'),
         required=False,

--- a/src/zeit/push/interfaces.py
+++ b/src/zeit/push/interfaces.py
@@ -90,9 +90,6 @@ class IPushMessages(zope.interface.Interface):
 
     """
 
-    date_last_pushed = zope.schema.Datetime(
-        title=_('Last push'), required=False, readonly=True)
-
     short_text = zope.schema.TextLine(
         title=_('Short push text'),
         required=False,

--- a/src/zeit/push/message.py
+++ b/src/zeit/push/message.py
@@ -132,11 +132,7 @@ class AccountData(grok.Adapter):
     def facebook_main_text(self):
         source = zeit.push.interfaces.facebookAccountSource(None)
         service = self._get_facebook_service(source.MAIN_ACCOUNT)
-        result = service and service.get('override_text')
-        if not result:  # BBB
-            push = zeit.push.interfaces.IPushMessages(self.context)
-            result = push.long_text
-        return result
+        return service and service.get('override_text')
 
     @property
     def facebook_magazin_enabled(self):
@@ -148,11 +144,7 @@ class AccountData(grok.Adapter):
     def facebook_magazin_text(self):
         source = zeit.push.interfaces.facebookAccountSource(None)
         service = self._get_facebook_service(source.MAGAZIN_ACCOUNT)
-        result = service and service.get('override_text')
-        if not result:  # BBB
-            push = zeit.push.interfaces.IPushMessages(self.context)
-            result = push.long_text
-        return result
+        return service and service.get('override_text')
 
     @property
     def facebook_campus_enabled(self):
@@ -164,8 +156,7 @@ class AccountData(grok.Adapter):
     def facebook_campus_text(self):
         source = zeit.push.interfaces.facebookAccountSource(None)
         service = self._get_facebook_service(source.CAMPUS_ACCOUNT)
-        result = service and service.get('override_text')
-        return result
+        return service and service.get('override_text')
 
     def _get_facebook_service(self, account):
         for service in self.message_config:

--- a/src/zeit/push/mock-webservice.zcml
+++ b/src/zeit/push/mock-webservice.zcml
@@ -5,9 +5,6 @@
   <utility factory=".testing.MobilePushNotifier" name="urbanairship" />
   <utility factory=".testing.PushNotifier" name="twitter" />
   <utility factory=".testing.PushNotifier" name="facebook" />
-
   <utility factory=".testing.PushNotifier" name="homepage" />
-  <utility factory=".testing.PushNotifier" name="ios-legacy" />
-  <utility factory=".testing.PushNotifier" name="wrapper" />
 
 </configure>

--- a/src/zeit/push/real-webservice.zcml
+++ b/src/zeit/push/real-webservice.zcml
@@ -5,9 +5,6 @@
   <utility factory=".urbanairship.from_product_config" name="urbanairship" />
   <utility factory=".twitter.from_product_config" name="twitter" />
   <utility factory=".facebook.Connection" name="facebook" />
-
   <utility factory=".banner.homepage_banner" name="homepage" />
-  <utility factory=".banner.ios_legacy" name="ios-legacy" />
-  <utility factory=".banner.wrapper_banner" name="wrapper" />
 
 </configure>

--- a/src/zeit/push/testing.py
+++ b/src/zeit/push/testing.py
@@ -45,8 +45,7 @@ class PushMockLayer(plone.testing.Layer):
     """Helper layer to reset mock notifiers."""
 
     def testSetUp(self):
-        for service in ['urbanairship', 'twitter', 'facebook',
-                        'homepage', 'ios-legacy', 'wrapper']:
+        for service in ['urbanairship', 'twitter', 'facebook', 'homepage']:
             notifier = zope.component.getUtility(
                 zeit.push.interfaces.IPushNotifier, name=service)
             notifier.reset()

--- a/src/zeit/push/tests/test_facebook.py
+++ b/src/zeit/push/tests/test_facebook.py
@@ -79,12 +79,3 @@ class FacebookMessageTest(zeit.push.testing.TestCase):
         # (see zeit.push.workflow.PushMessages._create_message)
         message.config = push.message_config[0]
         self.assertEqual('facebook', message.text)
-
-    def test_uses_long_text_as_bbb_for_facebook_override_text(self):
-        content = ExampleContentType()
-        self.repository['foo'] = content
-        push = zeit.push.interfaces.IPushMessages(content)
-        push.long_text = 'facebook'
-        message = zope.component.getAdapter(
-            content, zeit.push.interfaces.IMessage, name='facebook')
-        self.assertEqual('facebook', message.text)

--- a/src/zeit/push/workflow.py
+++ b/src/zeit/push/workflow.py
@@ -1,9 +1,7 @@
-from datetime import datetime
-from zeit.cms.content.interfaces import WRITEABLE_ALWAYS, WRITEABLE_LIVE
+from zeit.cms.content.interfaces import WRITEABLE_ALWAYS
 from zeit.cms.i18n import MessageFactory as _
 import grokcore.component as grok
 import logging
-import pytz
 import zeit.cms.content.dav
 import zeit.cms.content.interfaces
 import zeit.objectlog.interfaces
@@ -44,6 +42,26 @@ class PushMessages(zeit.cms.content.dav.DAVPropertiesAdapter):
             content, zeit.push.interfaces.IMessage, name=typ)
         message.config = config
         return message
+
+    MISSING = object()
+
+    def get(self, **query):
+        for item in self.message_config:
+            found = {key: item.get(key, self.MISSING) for key in query}
+            if found == query:
+                return item
+
+    def set(self, query, **values):
+        config = self.message_config[:]
+        for item in config:
+            found = {key: item.get(key, self.MISSING) for key in query}
+            if found == query:
+                item.update(values)
+                break
+        else:
+            values.update(query)
+            config += (values,)
+        self.message_config = config
 
 
 @grok.subscribe(

--- a/src/zeit/push/workflow.py
+++ b/src/zeit/push/workflow.py
@@ -29,11 +29,6 @@ class PushMessages(zeit.cms.content.dav.DAVPropertiesAdapter):
         zeit.workflow.interfaces.WORKFLOW_NS,
         ('short_text',))
 
-    zeit.cms.content.dav.mapProperties(
-        zeit.push.interfaces.IPushMessages,
-        zeit.workflow.interfaces.WORKFLOW_NS,
-        ('date_last_pushed',), writeable=WRITEABLE_LIVE)
-
     @property
     def messages(self):
         result = []
@@ -82,5 +77,3 @@ def send_push_on_publish(context, event):
                 mapping={'type': message.type.capitalize(), 'reason': str(e)}))
             log.error('Error during push to %s with config %s',
                       message.type, config, exc_info=True)
-
-    push.date_last_pushed = datetime.now(pytz.UTC)

--- a/src/zeit/push/workflow.py
+++ b/src/zeit/push/workflow.py
@@ -27,8 +27,7 @@ class PushMessages(zeit.cms.content.dav.DAVPropertiesAdapter):
     zeit.cms.content.dav.mapProperties(
         zeit.push.interfaces.IPushMessages,
         zeit.workflow.interfaces.WORKFLOW_NS,
-        # BBB long_text now in message_config for individual facebook accounts
-        ('long_text', 'short_text'))
+        ('short_text',))
 
     zeit.cms.content.dav.mapProperties(
         zeit.push.interfaces.IPushMessages,


### PR DESCRIPTION
Enthält einige Aufräumarbeiten, am besten commitweise anschauen.