### PR TITLE
ZON-4009, ZON-4011, ZON-4014: Extend mobile push UI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'tweepy',
         'urbanairship >= 1.0',
         'zc.sourcefactory',
-        'zeit.cms >= 2.90.0.dev0',
+        'zeit.cms >= 2.101.0.dev0',
         'zeit.content.article',
         'zeit.content.image',
         'zeit.objectlog',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'tweepy',
         'urbanairship >= 1.0',
         'zc.sourcefactory',
-        'zeit.cms >= 2.101.0.dev0',
+        'zeit.cms >= 2.102.0.dev0',
         'zeit.content.article',
         'zeit.content.image',
         'zeit.objectlog',

--- a/src/zeit/push/__init__.py
+++ b/src/zeit/push/__init__.py
@@ -16,6 +16,7 @@ product_config = """\
   channel-breaking Eilmeldung
   channel-news News
   urbanairship-audience-group subscriptions
+  mobile-buttons file://{fixtures}/mobile-buttons.xml
 </product-config>
 """.format(fixtures=pkg_resources.resource_filename(
     __name__, 'tests/fixtures'))

--- a/src/zeit/push/browser/form.py
+++ b/src/zeit/push/browser/form.py
@@ -56,7 +56,7 @@ class MobileBase(Base):
 
     mobile_fields = gocept.form.grouped.Fields(
         _("Mobile apps"),
-        ('mobile_text', 'mobile_enabled'),
+        ('mobile_title', 'mobile_text', 'mobile_enabled'),
         css_class='wide-widgets column-left')
 
     def __init__(self, *args, **kw):
@@ -67,11 +67,12 @@ class MobileBase(Base):
     def mobile_form_fields(self):
         return self.FormFieldsFactory(
             zeit.push.interfaces.IAccountData).select(
-                'mobile_text', 'mobile_enabled')
+                'mobile_enabled', 'mobile_title', 'mobile_text')
 
     def setUpWidgets(self, *args, **kw):
         super(MobileBase, self).setUpWidgets(*args, **kw)
         if self.request.form.get('%s.mobile_enabled' % self.prefix):
+            self._set_widget_required('mobile_title')
             self._set_widget_required('mobile_text')
 
 

--- a/src/zeit/push/browser/form.py
+++ b/src/zeit/push/browser/form.py
@@ -57,7 +57,7 @@ class MobileBase(Base):
     mobile_fields = gocept.form.grouped.Fields(
         _("Mobile apps"),
         ('mobile_title', 'mobile_text', 'mobile_enabled',
-         'mobile_uses_image', 'mobile_image'),
+         'mobile_uses_image', 'mobile_image', 'mobile_buttons'),
         css_class='wide-widgets column-left')
 
     def __init__(self, *args, **kw):
@@ -69,7 +69,7 @@ class MobileBase(Base):
         return self.FormFieldsFactory(
             zeit.push.interfaces.IAccountData).select(
                 'mobile_enabled', 'mobile_title', 'mobile_text',
-                'mobile_uses_image', 'mobile_image')
+                'mobile_uses_image', 'mobile_image', 'mobile_buttons')
 
     def setUpWidgets(self, *args, **kw):
         super(MobileBase, self).setUpWidgets(*args, **kw)

--- a/src/zeit/push/browser/form.py
+++ b/src/zeit/push/browser/form.py
@@ -56,7 +56,8 @@ class MobileBase(Base):
 
     mobile_fields = gocept.form.grouped.Fields(
         _("Mobile apps"),
-        ('mobile_title', 'mobile_text', 'mobile_enabled'),
+        ('mobile_title', 'mobile_text', 'mobile_enabled',
+         'mobile_uses_image', 'mobile_image'),
         css_class='wide-widgets column-left')
 
     def __init__(self, *args, **kw):
@@ -67,12 +68,15 @@ class MobileBase(Base):
     def mobile_form_fields(self):
         return self.FormFieldsFactory(
             zeit.push.interfaces.IAccountData).select(
-                'mobile_enabled', 'mobile_title', 'mobile_text')
+                'mobile_enabled', 'mobile_title', 'mobile_text',
+                'mobile_uses_image', 'mobile_image')
 
     def setUpWidgets(self, *args, **kw):
         super(MobileBase, self).setUpWidgets(*args, **kw)
         if self.request.form.get('%s.mobile_enabled' % self.prefix):
             self._set_widget_required('mobile_text')
+        if self.request.form.get('%s.mobile_uses_image' % self.prefix):
+            self._set_widget_required('mobile_image')
         if hasattr(self.widgets['mobile_text'], 'extra'):
             # i.e. we're not in read-only mode
             self.widgets['mobile_text'].extra += (

--- a/src/zeit/push/browser/form.py
+++ b/src/zeit/push/browser/form.py
@@ -72,8 +72,11 @@ class MobileBase(Base):
     def setUpWidgets(self, *args, **kw):
         super(MobileBase, self).setUpWidgets(*args, **kw)
         if self.request.form.get('%s.mobile_enabled' % self.prefix):
-            self._set_widget_required('mobile_title')
             self._set_widget_required('mobile_text')
+        if hasattr(self.widgets['mobile_text'], 'extra'):
+            # i.e. we're not in read-only mode
+            self.widgets['mobile_text'].extra += (
+                ' cms:charwarning="40" cms:charlimit="150"')
 
 
 class SocialAddForm(

--- a/src/zeit/push/browser/form.py
+++ b/src/zeit/push/browser/form.py
@@ -81,6 +81,7 @@ class MobileBase(Base):
             # i.e. we're not in read-only mode
             self.widgets['mobile_text'].extra += (
                 ' cms:charwarning="40" cms:charlimit="150"')
+            self.widgets['mobile_text'].cssClass = 'js-addbullet'
 
 
 class SocialAddForm(

--- a/src/zeit/push/browser/tests/test_form.py
+++ b/src/zeit/push/browser/tests/test_form.py
@@ -65,7 +65,7 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
             push.message_config)
         self.assertIn(
             {'type': 'mobile', 'enabled': True, 'override_text': 'mobile',
-             'title': 'mobile title',
+             'title': 'mobile title', 'uses_image': False,
              'channels': zeit.push.interfaces.CONFIG_CHANNEL_NEWS},
             push.message_config)
 
@@ -96,7 +96,7 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
             push.message_config)
         self.assertIn(
             {'type': 'mobile', 'enabled': False, 'override_text': 'mobile',
-             'title': 'mobile title',
+             'title': 'mobile title', 'uses_image': False,
              'channels': zeit.push.interfaces.CONFIG_CHANNEL_NEWS},
             push.message_config)
 
@@ -155,6 +155,26 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         self.assertEqual('mobile', service['override_text'])
         self.open_form()
         self.assertEqual('mobile', b.getControl('Mobile text').value)
+
+    def test_stores_mobile_image(self):
+        self.open_form()
+        b = self.browser
+        b.getControl('Mobile image').value = (
+            'http://xml.zeit.de/2006/DSC00109_2.JPG')
+        b.getControl('Apply').click()
+        article = self.get_article()
+        push = zeit.push.interfaces.IPushMessages(article)
+        service = push.get(type='mobile')
+        self.assertEqual(
+            'http://xml.zeit.de/2006/DSC00109_2.JPG', service['image'])
+
+        self.open_form()
+        b.getControl('Mobile image').value = ''
+        b.getControl('Apply').click()
+        article = self.get_article()
+        push = zeit.push.interfaces.IPushMessages(article)
+        service = push.get(type='mobile')
+        self.assertEqual(None, service['image'])
 
 
 class SocialAddFormTest(zeit.cms.testing.BrowserTestCase):

--- a/src/zeit/push/browser/tests/test_form.py
+++ b/src/zeit/push/browser/tests/test_form.py
@@ -44,7 +44,8 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         b.getControl('Enable Facebook', index=0).selected = True
         b.getControl('Facebook Main Text').value = 'fb-main'
         b.getControl('Enable mobile push').selected = True
-        b.getControl('Mobile title').value = 'mobile'
+        b.getControl('Mobile title').value = 'mobile title'
+        b.getControl('Mobile text').value = 'mobile'
         b.getControl('Apply').click()
         article = self.get_article()
         push = zeit.push.interfaces.IPushMessages(article)
@@ -64,6 +65,7 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
             push.message_config)
         self.assertIn(
             {'type': 'mobile', 'enabled': True, 'override_text': 'mobile',
+             'title': 'mobile title',
              'channels': zeit.push.interfaces.CONFIG_CHANNEL_NEWS},
             push.message_config)
 
@@ -94,6 +96,7 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
             push.message_config)
         self.assertIn(
             {'type': 'mobile', 'enabled': False, 'override_text': 'mobile',
+             'title': 'mobile title',
              'channels': zeit.push.interfaces.CONFIG_CHANNEL_NEWS},
             push.message_config)
 
@@ -149,7 +152,8 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
     def test_stores_mobile_override_text(self):
         self.open_form()
         b = self.browser
-        b.getControl('Mobile title').value = 'mobile'
+        b.getControl('Mobile title').value = 'mobile title'
+        b.getControl('Mobile text').value = 'mobile'
         b.getControl('Apply').click()
         article = self.get_article()
         push = zeit.push.interfaces.IPushMessages(article)
@@ -161,7 +165,7 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         else:
             self.fail('mobile message_config is missing')
         self.open_form()
-        self.assertEqual('mobile', b.getControl('Mobile title').value)
+        self.assertEqual('mobile', b.getControl('Mobile text').value)
 
 
 class SocialAddFormTest(zeit.cms.testing.BrowserTestCase):

--- a/src/zeit/push/browser/tests/test_form.py
+++ b/src/zeit/push/browser/tests/test_form.py
@@ -138,14 +138,8 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         b.getControl('Apply').click()
         article = self.get_article()
         push = zeit.push.interfaces.IPushMessages(article)
-        for service in push.message_config:
-            if (service['type'] != 'facebook'
-                or service.get('account') != 'fb-test'):
-                continue
-            self.assertEqual('facebook', service['override_text'])
-            break
-        else:
-            self.fail('facebook message_config is missing')
+        service = push.get(type='facebook', account='fb-test')
+        self.assertEqual('facebook', service['override_text'])
         self.open_form()
         self.assertEqual('facebook', b.getControl('Facebook Main Text').value)
 
@@ -157,13 +151,8 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         b.getControl('Apply').click()
         article = self.get_article()
         push = zeit.push.interfaces.IPushMessages(article)
-        for service in push.message_config:
-            if service['type'] != 'mobile':
-                continue
-            self.assertEqual('mobile', service['override_text'])
-            break
-        else:
-            self.fail('mobile message_config is missing')
+        service = push.get(type='mobile')
+        self.assertEqual('mobile', service['override_text'])
         self.open_form()
         self.assertEqual('mobile', b.getControl('Mobile text').value)
 

--- a/src/zeit/push/browser/tests/test_form.py
+++ b/src/zeit/push/browser/tests/test_form.py
@@ -176,6 +176,16 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         service = push.get(type='mobile')
         self.assertEqual(None, service['image'])
 
+    def test_stores_mobile_buttons(self):
+        self.open_form()
+        b = self.browser
+        b.getControl('Mobile buttons').displayValue = ['Share']
+        b.getControl('Apply').click()
+        article = self.get_article()
+        push = zeit.push.interfaces.IPushMessages(article)
+        service = push.get(type='mobile')
+        self.assertEqual('share', service['buttons'])
+
 
 class SocialAddFormTest(zeit.cms.testing.BrowserTestCase):
 

--- a/src/zeit/push/interfaces.py
+++ b/src/zeit/push/interfaces.py
@@ -258,5 +258,8 @@ class IAccountData(zope.interface.Interface):
         source=twitterAccountSource,
         required=False)
 
-    mobile_text = zope.schema.TextLine(title=_('Mobile title'), required=False)
+    mobile_title = zope.schema.TextLine(
+        title=_('Mobile title'), required=False)
+    mobile_text = zope.schema.Text(
+        title=_('Mobile text'), required=False)
     mobile_enabled = zope.schema.Bool(title=_('Enable mobile push'))

--- a/src/zeit/push/interfaces.py
+++ b/src/zeit/push/interfaces.py
@@ -27,10 +27,7 @@ class IMessage(zope.interface.Interface):
         as parameters.
 
         Currently `additional_parameters` is only used for mobile push
-        notifications to enrich the parameteres with `teaserTitle`,
-        `teaserText`, `teaserSupertitle` and `image_url`. These information are
-        read from the context.
-
+        notifications to enrich the parameters with `image_url`.
         """
 
 

--- a/src/zeit/push/interfaces.py
+++ b/src/zeit/push/interfaces.py
@@ -234,6 +234,16 @@ class FacebookAccountSource(zeit.cms.content.sources.XMLSource):
 facebookAccountSource = FacebookAccountSource()
 
 
+class MobileButtonsSource(zeit.cms.content.sources.XMLSource):
+
+    product_configuration = 'zeit.push'
+    config_url = 'mobile-buttons'
+    attribute = 'id'
+
+
+MOBILE_BUTTONS_SOURCE = MobileButtonsSource()
+
+
 class IAccountData(zope.interface.Interface):
     """Convenience access to IPushMessages.message_config entries"""
 
@@ -270,4 +280,8 @@ class IAccountData(zope.interface.Interface):
         title=_('Mobile image'),
         description=_("Drag an image group here"),
         source=zeit.content.image.interfaces.imageGroupSource,
+        required=False)
+    mobile_buttons = zope.schema.Choice(
+        title=_('Mobile buttons'),
+        source=MOBILE_BUTTONS_SOURCE,
         required=False)

--- a/src/zeit/push/interfaces.py
+++ b/src/zeit/push/interfaces.py
@@ -2,6 +2,7 @@ from zeit.cms.i18n import MessageFactory as _
 import xml.sax.saxutils
 import zc.sourcefactory.source
 import zeit.cms.content.sources
+import zeit.content.image.interfaces
 import zope.interface
 import zope.schema
 
@@ -263,3 +264,10 @@ class IAccountData(zope.interface.Interface):
     mobile_text = zope.schema.Text(
         title=_('Mobile text'), required=False)
     mobile_enabled = zope.schema.Bool(title=_('Enable mobile push'))
+
+    mobile_uses_image = zope.schema.Bool(title=_('Mobile push with image'))
+    mobile_image = zope.schema.Choice(
+        title=_('Mobile image'),
+        description=_("Drag an image group here"),
+        source=zeit.content.image.interfaces.imageGroupSource,
+        required=False)

--- a/src/zeit/push/message.py
+++ b/src/zeit/push/message.py
@@ -304,3 +304,15 @@ class AccountData(grok.Adapter):
         self.push.set(dict(
             type='mobile', channels=zeit.push.interfaces.CONFIG_CHANNEL_NEWS),
             image=value)
+
+    @property
+    def mobile_buttons(self):
+        service = self.push.get(
+            type='mobile', channels=zeit.push.interfaces.CONFIG_CHANNEL_NEWS)
+        return service and service.get('buttons')
+
+    @mobile_buttons.setter
+    def mobile_buttons(self, value):
+        self.push.set(dict(
+            type='mobile', channels=zeit.push.interfaces.CONFIG_CHANNEL_NEWS),
+            buttons=value)

--- a/src/zeit/push/message.py
+++ b/src/zeit/push/message.py
@@ -276,3 +276,31 @@ class AccountData(grok.Adapter):
         self.push.set(dict(
             type='mobile', channels=zeit.push.interfaces.CONFIG_CHANNEL_NEWS),
             override_text=value)
+
+    @property
+    def mobile_uses_image(self):
+        service = self.push.get(
+            type='mobile', channels=zeit.push.interfaces.CONFIG_CHANNEL_NEWS)
+        return service and service.get('uses_image')
+
+    @mobile_uses_image.setter
+    def mobile_uses_image(self, value):
+        self.push.set(dict(
+            type='mobile', channels=zeit.push.interfaces.CONFIG_CHANNEL_NEWS),
+            uses_image=value)
+
+    @property
+    def mobile_image(self):
+        service = self.push.get(
+            type='mobile', channels=zeit.push.interfaces.CONFIG_CHANNEL_NEWS)
+        if not service:
+            return None
+        return zeit.cms.interfaces.ICMSContent(service.get('image'), None)
+
+    @mobile_image.setter
+    def mobile_image(self, value):
+        if value is not None:
+            value = value.uniqueId
+        self.push.set(dict(
+            type='mobile', channels=zeit.push.interfaces.CONFIG_CHANNEL_NEWS),
+            image=value)

--- a/src/zeit/push/message.py
+++ b/src/zeit/push/message.py
@@ -254,6 +254,18 @@ class AccountData(grok.Adapter):
             enabled=value)
 
     @property
+    def mobile_title(self):
+        service = self.push.get(
+            type='mobile', channels=zeit.push.interfaces.CONFIG_CHANNEL_NEWS)
+        return service and service.get('title')
+
+    @mobile_title.setter
+    def mobile_title(self, value):
+        self.push.set(dict(
+            type='mobile', channels=zeit.push.interfaces.CONFIG_CHANNEL_NEWS),
+            title=value)
+
+    @property
     def mobile_text(self):
         service = self.push.get(
             type='mobile', channels=zeit.push.interfaces.CONFIG_CHANNEL_NEWS)

--- a/src/zeit/push/tests/fixtures/mobile-buttons.xml
+++ b/src/zeit/push/tests/fixtures/mobile-buttons.xml
@@ -1,0 +1,5 @@
+<buttons>
+  <button id="yesno">Ja/Nein</button>
+  <button id="share">Share</button>
+  <button id="thumbs">Thumbsup/down</button>
+</buttons>

--- a/src/zeit/push/tests/test_urbanairship.py
+++ b/src/zeit/push/tests/test_urbanairship.py
@@ -294,7 +294,8 @@ class MessageTest(zeit.push.testing.TestCase):
             zeit.push.interfaces.IMessage, name=self.name)
         message.send()
         self.assertEqual(
-            [('content_title', u'http://www.zeit.de/content', {})],
+            [('content_title', u'http://www.zeit.de/content',
+              {'mobile_title': None})],
             self.get_calls('urbanairship'))
 
     def test_message_text_favours_override_text_over_title(self):
@@ -345,7 +346,8 @@ class IntegrationTest(zeit.push.testing.TestCase):
         self.publish(self.content)
         self.assertEqual([(
             'content_title', u'http://www.zeit.de/content',
-            {'enabled': True, 'type': 'mobile'})],
+            {'enabled': True, 'type': 'mobile',
+             'mobile_title': None})],
             zope.component.getUtility(
                 zeit.push.interfaces.IPushNotifier, name='urbanairship').calls)
 

--- a/src/zeit/push/tests/test_urbanairship.py
+++ b/src/zeit/push/tests/test_urbanairship.py
@@ -294,9 +294,7 @@ class MessageTest(zeit.push.testing.TestCase):
             zeit.push.interfaces.IMessage, name=self.name)
         message.send()
         self.assertEqual(
-            [('content_title', u'http://www.zeit.de/content', {
-                'teaserSupertitle': 'super', 'teaserText': 'teaser',
-                'teaserTitle': 'title'})],
+            [('content_title', u'http://www.zeit.de/content', {})],
             self.get_calls('urbanairship'))
 
     def test_message_text_favours_override_text_over_title(self):

--- a/src/zeit/push/urbanairship.py
+++ b/src/zeit/push/urbanairship.py
@@ -251,10 +251,6 @@ class Message(zeit.push.message.Message):
     @zope.cachedescriptors.property.Lazy
     def additional_parameters(self):
         result = {}
-        for name in ['teaserTitle', 'teaserText', 'teaserSupertitle']:
-            value = getattr(self.context, name)
-            if value:
-                result[name] = value
         if self.image:
             result['image_url'] = self.image.uniqueId.replace(
                 zeit.cms.interfaces.ID_NAMESPACE,
@@ -311,11 +307,7 @@ def print_payload_documentation():
     conn = PayloadDocumentation(
         'android_application_key', 'android_master_secret',
         'ios_application_key', 'ios_master_secret', expire_interval=9000)
-    params = {
-        'teaserTitle': 'TeaserTitle',
-        'teaserText': 'TeaserText',
-        'teaserSupertitle': 'TeaserSupertitle',
-    }
+    params = {}
     print '[{"//": "*** Eilmeldung ***"},'
     conn.send('PushTitle', 'http://www.zeit.de/test/artikel',
               channels=CONFIG_CHANNEL_BREAKING, **params)

--- a/src/zeit/push/urbanairship.py
+++ b/src/zeit/push/urbanairship.py
@@ -250,7 +250,9 @@ class Message(zeit.push.message.Message):
 
     @zope.cachedescriptors.property.Lazy
     def additional_parameters(self):
-        result = {}
+        result = {
+            'mobile_title': self.config.get('title'),
+        }
         if self.image:
             result['image_url'] = self.image.uniqueId.replace(
                 zeit.cms.interfaces.ID_NAMESPACE,


### PR DESCRIPTION
Das ist erstmal _nur_ das UI, die Daten werden noch nirgends verwendet.

Zuerst https://github.com/ZeitOnline/zeit.push/pull/17 mergen!

Needs https://github.com/ZeitOnline/zeit.cms/pull/61 and https://github.com/ZeitOnline/zeit.locales/pull/27 and https://github.com/ZeitOnline/vivi-deployment/pull/34