### PR TITLE
BUG-201: Disable homepage banner message config only on commit, not immediately

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,8 @@ zeit.push changes
 
 - BUG-621: Log Twitter and Facebook account name to objectlog
 
+- BUG-201: Make homepage publisher safe from ConflictErrors
+
 - MAINT: Remove obsolete banner control files (wrapper, ios-legacy)
 
 - MAINT: Remove broken/unused ``IPushMessages.date_last_pushed``

--- a/src/zeit/push/banner.py
+++ b/src/zeit/push/banner.py
@@ -8,6 +8,7 @@ from zeit.content.article.edit.interfaces import IBreakingNewsBody
 import grokcore.component as grok
 import logging
 import pytz
+import transaction
 import zeit.push.interfaces
 import zeit.push.message
 import zope.app.appsetup.product
@@ -68,3 +69,11 @@ class HomepageMessage(zeit.push.message.Message):
 
     grok.name('homepage')
     get_text_from = 'short_text'
+
+    def _disable_message_config(self):
+        transaction.get().addAfterCommitHook(
+            self._disable_message_config_on_commit)
+
+    def _disable_message_config_on_commit(self, commit_success):
+        if commit_success:
+            super(HomepageMessage, self)._disable_message_config()

--- a/src/zeit/push/message.py
+++ b/src/zeit/push/message.py
@@ -32,8 +32,7 @@ class Message(grok.Adapter):
         Re-sending can be done manually by re-enabling the service.
 
         """
-        push = zeit.push.interfaces.IPushMessages(self.context)
-        push.set(self.config, enabled=False)
+        self._disable_message_config()
         if not self.text:
             raise ValueError('No text configured')
         kw = {}
@@ -50,6 +49,10 @@ class Message(grok.Adapter):
             self.log_error(str(e))
             log.error(u'Error during push to %s with config %s',
                       self.type, self.config, exc_info=True)
+
+    def _disable_message_config(self):
+        push = zeit.push.interfaces.IPushMessages(self.context)
+        push.set(self.config, enabled=False)
 
     @property
     def text(self):

--- a/src/zeit/push/tests/test_banner.py
+++ b/src/zeit/push/tests/test_banner.py
@@ -1,9 +1,11 @@
 # coding: utf-8
+from zeit.cms.checkout.helper import checked_out
 from zeit.cms.checkout.interfaces import ICheckoutManager
 from zeit.cms.content.interfaces import ISemanticChange
 from zeit.cms.workflow.interfaces import IPublishInfo
 from zeit.content.article.edit.interfaces import IEditableBody
 import lxml.etree
+import transaction
 import zeit.content.article.testing
 import zeit.push.banner
 import zeit.push.testing
@@ -57,3 +59,17 @@ class StaticArticlePublisherTest(zeit.push.testing.TestCase):
         zope.security.management.endInteraction()
         zeit.cms.testing.create_interaction('zope.user')
         self.publisher.send('mytext', 'http://zeit.de/foo')
+
+    def test_disables_message_config_only_on_commit(self):
+        content = self.repository['testcontent']
+        with checked_out(content) as co:
+            push = zeit.push.interfaces.IPushMessages(co)
+            push.short_text = u'banner'
+            push.set({'type': 'homepage'}, enabled=True)
+        push = zeit.push.interfaces.IPushMessages(content)
+        push.messages[0].send()
+        transaction.abort()
+        self.assertEqual(True, push.get(type='homepage')['enabled'])
+        push.messages[0].send()
+        transaction.commit()
+        self.assertEqual(False, push.get(type='homepage')['enabled'])


### PR DESCRIPTION
The usual error case goes something like this:
* Publish breaking news article
* AfterPublish updates banner object, schedules publish
* message config is disabled (written immediately since DAV has no transactions)
* During commit of the article publish there's a conflict (most likely: DAV cache)
* article publish is retried, but during the retried AfterPublish, the
  message config already is disabled and thus is NOT retried

By disabling the message config only on a successful commit, this problem should be alleviated.