### PR TITLE
ZON-4010: Prefill mobile title when payload template changes

### DIFF
--- a/src/zeit/push/browser/configure.zcml
+++ b/src/zeit/push/browser/configure.zcml
@@ -57,6 +57,12 @@
     permission="zeit.workflow.Publish"
     />
 
+  <browser:page
+    for="zope.location.interfaces.ISite"
+    name="zeit.push.payload_template_title"
+    class=".mobile.FindTitle"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    permission="zope.View"
+    />
+
 </configure>
-
-

--- a/src/zeit/push/browser/mobile.py
+++ b/src/zeit/push/browser/mobile.py
@@ -1,0 +1,20 @@
+import logging
+import json
+import zeit.push.interfaces
+
+log = logging.getLogger(__name__)
+
+
+class FindTitle(object):
+
+    def __call__(self):
+        name = self.request.form.get('q')
+        if not name:
+            return ''
+        template = zeit.push.interfaces.PAYLOAD_TEMPLATE_SOURCE.factory.find(
+            name)
+        try:
+            return json.loads(template.text)['default_title']
+        except:
+            log.debug('No default title for %s', name, exc_info=True)
+            return ''

--- a/src/zeit/push/browser/resources.py
+++ b/src/zeit/push/browser/resources.py
@@ -5,3 +5,4 @@ import zeit.cms.browser.resources
 lib = Library('zeit.push', 'resources')
 Resource('push.css')
 Resource('social.js', depends=[zeit.cms.browser.resources.base])
+Resource('mobile.js', depends=[zeit.cms.browser.resources.base])

--- a/src/zeit/push/browser/resources/mobile.js
+++ b/src/zeit/push/browser/resources/mobile.js
@@ -1,0 +1,31 @@
+(function($) {
+
+var update_title = function(event) {
+    var select = $(event.target);
+    var form = select.closest('form');
+    var input = form.find('.fieldname-mobile_title input');
+    $.ajax({
+        type: 'GET',
+        url: window.application_url + '/@@zeit.push.payload_template_title',
+        data: {'q': select.val()},
+        success: function(data) {
+            input.val(data);
+        },
+        error: function(request, error) {
+            input.val('');
+        }
+    });
+};
+
+$(document).bind('fragment-ready', function(event) {
+    $('select#mobile\\.mobile_payload_template', event.__target).unbind(
+    'change.zeit.article.mobile.payload_template').bind(
+        'change.zeit.article.mobile.payload_template', update_title);
+
+});
+
+$(document).ready(function() {
+    $('select#form\\.mobile_payload_template').bind('change', update_title);
+});
+
+}(jQuery));

--- a/src/zeit/push/browser/tests/test_form.py
+++ b/src/zeit/push/browser/tests/test_form.py
@@ -197,6 +197,24 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         service = push.get(type='mobile')
         self.assertEqual('foo.json', service['payload_template'])
 
+    def test_payload_template_is_required_when_enabled(self):
+        self.open_form()
+        b = self.browser
+        b.getControl('Enable mobile push').selected = True
+        b.getControl('Mobile text').value = 'foo'
+        b.getControl('Payload Template').displayValue = []
+        b.getControl('Apply').click()
+        self.assertEllipsis(
+            '...Payload Template...Required input is missing...', b.contents)
+        b.getControl('Payload Template').displayValue = ['Foo']
+        b.getControl('Apply').click()
+        self.assertEllipsis('...Updated on...', b.contents)
+
+        b.getControl('Enable mobile push').selected = False
+        b.getControl('Payload Template').displayValue = []
+        b.getControl('Apply').click()
+        self.assertEllipsis('...Updated on...', b.contents)
+
 
 class SocialAddFormTest(SocialFormTest):
 

--- a/src/zeit/push/browser/tests/test_mobile.py
+++ b/src/zeit/push/browser/tests/test_mobile.py
@@ -1,0 +1,19 @@
+import zeit.push.testing
+import zeit.cms.testing
+
+
+class FindTitleTest(zeit.cms.testing.SeleniumTestCase):
+
+    layer = zeit.push.testing.WEBDRIVER_LAYER
+
+    def setUp(self):
+        super(FindTitleTest, self).setUp()
+        self.open('/repository/testcontent/@@checkout')
+        s = self.selenium
+        s.open(s.getLocation().replace('edit', 'edit-social'))
+
+    def test_headline_from_template_is_inserted_as_push_title(self):
+        s = self.selenium
+        s.waitForElementPresent('form.mobile_payload_template')
+        s.select('form.mobile_payload_template', 'label=Foo')
+        self.assertEqual('Default title', s.getValue('form.mobile_title'))

--- a/src/zeit/push/message.py
+++ b/src/zeit/push/message.py
@@ -307,7 +307,10 @@ class AccountData(grok.Adapter):
 
     @mobile_payload_template.setter
     def mobile_payload_template(self, value):
-        token = zeit.push.interfaces.PAYLOAD_TEMPLATE_SOURCE.factory.getToken(
-            value)
+        if value is None:
+            token = None
+        else:
+            token = zeit.push.interfaces.PAYLOAD_TEMPLATE_SOURCE\
+                .factory.getToken(value)
         # Use the token here instead of the value
         self.push.set(dict(type='mobile'), payload_template=token)

--- a/src/zeit/push/tests/fixtures/payloadtemplate.json
+++ b/src/zeit/push/tests/fixtures/payloadtemplate.json
@@ -1,4 +1,6 @@
-[
+{
+  "default_title": "Default title",
+  "messages": [
   {
     "audience": {
       "OR": [
@@ -61,4 +63,4 @@
       }
     }
   }
-]
+]}

--- a/src/zeit/push/tests/test_urbanairship.py
+++ b/src/zeit/push/tests/test_urbanairship.py
@@ -169,21 +169,17 @@ class MessageTest(zeit.push.testing.TestCase,
     def test_changes_to_template_are_applied_immediately(self):
         message = zeit.push.urbanairship.Message(
             self.repository['testcontent'])
-        self.create_payload_template('{"one": 1}', 'foo.json')
+        self.create_payload_template('{"messages": {"one": 1}}', 'foo.json')
         message.config['payload_template'] = 'foo.json'
         self.assertEqual({'one': 1}, message.render())
-        self.create_payload_template('{"two": 1}', 'foo.json')
+        self.create_payload_template('{"messages": {"two": 1}}', 'foo.json')
         self.assertEqual({'two': 1}, message.render())
 
     def test_payload_loads_jinja_payload_variables(self):
-        template_content = u"""
-        [
-            {
-                "title": "{{article.title}}",
-                "message": "{%if not uses_image %}Bildß{% endif %}"
-            }
-        ]
-        """
+        template_content = u"""{"messages":[{
+            "title": "{{article.title}}",
+            "message": "{%if not uses_image %}Bildß{% endif %}"
+        }]}"""
         self.create_payload_template(template_content, 'bar.json')
         message = zope.component.getAdapter(
             self.create_content(),

--- a/src/zeit/push/urbanairship.py
+++ b/src/zeit/push/urbanairship.py
@@ -122,7 +122,7 @@ class Message(zeit.push.message.Message):
         # If not proper json, a pretty good ValueError will be raised here.
         result = json.loads(text, strict=False)
         # XXX Maybe use the urbanairship python module validation API.
-        return result
+        return result['messages']
 
     def find_template(self, name):
         source = zeit.push.interfaces.PAYLOAD_TEMPLATE_SOURCE.factory


### PR DESCRIPTION
Wenn das gemerged wird, ändert sich der Grundaufbau der Templates.

vorher:
```js
[ {"message": ...}, {"message": ... } ]
```

neu:
```js
{
  "default_title": "Default title",
  "messages": [  {"message": ...}, {"message": ... } ]}
}
```