### PR TITLE
ZON-4494: Add separate tweet text for twitter cross-posting

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.push changes
 =================
 
-1.22.2 (unreleased)
+1.23.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-4494: Add separate tweet text for twitter cross-posting
 
 
 1.22.1 (2017-11-09)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.push',
-    version='1.22.2.dev0',
+    version='1.23.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/push/browser/form.py
+++ b/src/zeit/push/browser/form.py
@@ -23,7 +23,7 @@ class SocialBase(Base):
         _("Social media"),
         ('facebook_main_text', 'facebook_main_enabled',
          'short_text', 'twitter_main_enabled',
-         'twitter_ressort_enabled', 'twitter_ressort'),
+         'twitter_ressort_text', 'twitter_ressort_enabled', 'twitter_ressort'),
         css_class='wide-widgets column-left')
 
     def __init__(self, *args, **kw):
@@ -41,15 +41,18 @@ class SocialBase(Base):
             self.FormFieldsFactory(
                 zeit.push.interfaces.IAccountData).select(
                     'twitter_main_enabled',
+                    'twitter_ressort_text',
                     'twitter_ressort_enabled', 'twitter_ressort'))
 
     def setUpWidgets(self, *args, **kw):
         super(SocialBase, self).setUpWidgets(*args, **kw)
         self.set_charlimit('short_text')
+        self.set_charlimit('twitter_ressort_text')
         if self.request.form.get('%s.facebook_main_enabled' % self.prefix):
             self._set_widget_required('facebook_main_text')
         if self.request.form.get('%s.twitter_ressort_enabled' % self.prefix):
             self._set_widget_required('twitter_ressort')
+            self._set_widget_required('twitter_ressort_text')
 
 
 class MobileBase(Base):

--- a/src/zeit/push/browser/tests/test_form.py
+++ b/src/zeit/push/browser/tests/test_form.py
@@ -40,6 +40,7 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         b.getControl('Enable Twitter', index=0).selected = True
         b.getControl('Enable Twitter Ressort').selected = True
         b.getControl('Additional Twitter').displayValue = ['Wissen']
+        b.getControl('Ressort Tweet').value = 'additional ressort tweet'
         b.getControl('Enable Facebook', index=0).selected = True
         b.getControl('Facebook Main Text').value = 'fb-main'
         b.getControl('Enable mobile push').selected = True
@@ -56,7 +57,8 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
             push.message_config)
         self.assertIn(
             {'type': 'twitter', 'enabled': True, 'variant': 'ressort',
-             'account': 'twitter_ressort_wissen'},
+             'account': 'twitter_ressort_wissen',
+             'override_text': 'additional ressort tweet'},
             push.message_config)
         self.assertIn(
             {'type': 'facebook', 'enabled': True, 'account': 'fb-test',
@@ -87,7 +89,8 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
             push.message_config)
         self.assertIn(
             {'type': 'twitter', 'enabled': False, 'variant': 'ressort',
-             'account': 'twitter_ressort_wissen'},
+             'account': 'twitter_ressort_wissen',
+             'override_text': 'additional ressort tweet'},
             push.message_config)
         self.assertIn(
             {'type': 'facebook', 'enabled': False, 'account': 'fb-test',
@@ -110,12 +113,14 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         b = self.browser
         b.getControl('Enable Twitter Ressort').selected = True
         b.getControl('Additional Twitter').displayValue = ['Wissen']
+        b.getControl('Ressort Tweet').value = 'additional ressort tweet'
         b.getControl('Apply').click()
         article = self.get_article()
         push = zeit.push.interfaces.IPushMessages(article)
         self.assertIn(
             {'type': 'twitter', 'enabled': True, 'variant': 'ressort',
-             'account': 'twitter_ressort_wissen'},
+             'account': 'twitter_ressort_wissen',
+             'override_text': 'additional ressort tweet'},
             push.message_config)
 
         self.open_form()

--- a/src/zeit/push/interfaces.py
+++ b/src/zeit/push/interfaces.py
@@ -301,6 +301,10 @@ class IAccountData(zope.interface.Interface):
         title=_('Facebook Campus Text'), required=False)
 
     twitter_main_enabled = zope.schema.Bool(title=_('Enable Twitter'))
+    twitter_ressort_text = zope.schema.TextLine(
+        title=_('Ressort Tweet'),
+        required=False,
+        max_length=256)
     twitter_ressort_enabled = zope.schema.Bool(
         title=_('Enable Twitter Ressort'))
     twitter_ressort = zope.schema.Choice(

--- a/src/zeit/push/message.py
+++ b/src/zeit/push/message.py
@@ -210,6 +210,15 @@ class AccountData(grok.Adapter):
             enabled=value)
 
     @property
+    def twitter_ressort_text(self):
+        return self._nonmain_twitter_service.get('override_text')
+
+    @twitter_ressort_text.setter
+    def twitter_ressort_text(self, value):
+        self.push.set(
+            dict(type='twitter', variant='ressort'), override_text=value)
+
+    @property
     def twitter_ressort(self):
         return self._nonmain_twitter_service.get('account')
 

--- a/src/zeit/push/tests/test_twitter.py
+++ b/src/zeit/push/tests/test_twitter.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import gocept.testing.assertion
 import os
 import time
@@ -6,6 +7,7 @@ import tweepy
 import zeit.push.interfaces
 import zeit.push.testing
 import zeit.push.twitter
+import zope.component
 
 
 class TwitterTest(zeit.push.testing.TestCase,
@@ -61,3 +63,20 @@ class TwitterAccountsTest(zeit.push.testing.TestCase):
         self.assertEqual(
             ['twitter_ressort_wissen', 'twitter_ressort_politik'],
             list(zeit.push.interfaces.twitterAccountSource(None)))
+
+
+class TwitterMessageTest(zeit.push.testing.TestCase):
+
+    def test_uses_twitter_ressort_override_text(self):
+        content = ExampleContentType()
+        self.repository['foo'] = content
+        push = zeit.push.interfaces.IPushMessages(content)
+        push.message_config = [{
+            'type': 'twitter', 'account': 'twitter_ressort_wissen',
+            'variant': 'ressort', 'enabled': True, 'override_text': 'foobar'}]
+        message = zope.component.getAdapter(
+            content, zeit.push.interfaces.IMessage, name='twitter')
+        # XXX This API is a bit unwieldy
+        # (see zeit.push.workflow.PushMessages._create_message)
+        message.config = push.message_config[0]
+        self.assertEqual('foobar', message.text)

--- a/src/zeit/push/twitter.py
+++ b/src/zeit/push/twitter.py
@@ -51,7 +51,14 @@ def from_product_config():
 class Message(zeit.push.message.Message):
 
     grok.name('twitter')
-    get_text_from = 'short_text'
+
+    @property
+    def text(self):
+        text = self.config.get('override_text')
+        if not text:  # BBB
+            self.get_text_from = 'short_text'
+            text = super(Message, self).text
+        return text
 
     @property
     def log_message_details(self):


### PR DESCRIPTION
Ticket: https://zeit-online.atlassian.net/browse/ZON-4494

Question: How can I make sure that Eilmeldungen only send pushes to the main twitter account? I think this is the current implementation, but I'm not sure.