### PR TITLE
ZON-5075: Add separate fields for print twitter account

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.push changes
 =================
 
-1.26.2 (unreleased)
+1.27.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-5075: Add separate fields for print twitter account
 
 
 1.26.1 (2018-11-30)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.push',
-    version='1.26.2.dev0',
+    version='1.27.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/push/browser/form.py
+++ b/src/zeit/push/browser/form.py
@@ -23,7 +23,8 @@ class SocialBase(Base):
         _("Social media"),
         ('facebook_main_text', 'facebook_main_enabled',
          'short_text', 'twitter_main_enabled',
-         'twitter_ressort_text', 'twitter_ressort_enabled', 'twitter_ressort'),
+         'twitter_ressort_text', 'twitter_ressort_enabled', 'twitter_ressort',
+         'twitter_print_text', 'twitter_print_enabled'),
         css_class='wide-widgets column-left')
 
     def __init__(self, *args, **kw):
@@ -42,11 +43,13 @@ class SocialBase(Base):
                 zeit.push.interfaces.IAccountData).select(
                     'twitter_main_enabled',
                     'twitter_ressort_text',
-                    'twitter_ressort_enabled', 'twitter_ressort'))
+                    'twitter_ressort_enabled', 'twitter_ressort',
+                    'twitter_print_text', 'twitter_print_enabled'))
 
     def setUpWidgets(self, *args, **kw):
         super(SocialBase, self).setUpWidgets(*args, **kw)
         self.set_charlimit('short_text')
+        self.set_charlimit('twitter_print_text')
         self.set_charlimit('twitter_ressort_text')
         if self.request.form.get('%s.facebook_main_enabled' % self.prefix):
             self._set_widget_required('facebook_main_text')

--- a/src/zeit/push/browser/resources/push.css
+++ b/src/zeit/push/browser/resources/push.css
@@ -1,5 +1,6 @@
 .field.fieldname-twitter_enabled,
 .field.fieldname-twitter_ressort_enabled,
+.field.fieldname-twitter_print_enabled,
 .field.fieldname-facebook_main_enabled,
 .field.fieldname-facebook_magazin_enabled {
     float: left;
@@ -8,6 +9,8 @@
 .field.fieldname-short_text,
 .field.fieldname-facebook_magazin_text,
 .field.fieldname-twitter_ressort_enabled,
+.field.fieldname-twitter_print_text,
+.field.fieldname-twitter_print_enabled,
 .field.fieldname-mobile_text {
     clear: left;
 }

--- a/src/zeit/push/browser/tests/test_form.py
+++ b/src/zeit/push/browser/tests/test_form.py
@@ -40,8 +40,10 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         b = self.browser
         b.getControl('Enable Twitter', index=0).selected = True
         b.getControl('Enable Twitter Ressort').selected = True
+        b.getControl('Enable Twitter Print').selected = True
         b.getControl('Additional Twitter').displayValue = ['Wissen']
         b.getControl('Ressort Tweet').value = 'additional ressort tweet'
+        b.getControl('Print Tweet').value = 'additional print tweet'
         b.getControl('Enable Facebook', index=0).selected = True
         b.getControl('Facebook Main Text').value = 'fb-main'
         b.getControl('Enable mobile push').selected = True
@@ -50,9 +52,9 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         b.getControl('Apply').click()
         article = self.get_article()
         push = zeit.push.interfaces.IPushMessages(article)
-        # No entries for Facebook Magazin and Campus are created, since we
-        # did not enable those.
-        self.assertEqual(4, len(push.message_config))
+        # No entries for Facebook Magazin and Campus are created, since they
+        # are not included in the base form.
+        self.assertEqual(5, len(push.message_config))
         self.assertIn(
             {'type': 'twitter', 'enabled': True, 'account': 'twitter-test'},
             push.message_config)
@@ -60,6 +62,10 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
             {'type': 'twitter', 'enabled': True, 'variant': 'ressort',
              'account': 'twitter_ressort_wissen',
              'override_text': 'additional ressort tweet'},
+            push.message_config)
+        self.assertIn(
+            {'type': 'twitter', 'enabled': True, 'account': 'twitter-print',
+             'override_text': 'additional print tweet'},
             push.message_config)
         self.assertIn(
             {'type': 'facebook', 'enabled': True, 'account': 'fb-test',
@@ -74,17 +80,19 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         self.open_form()
         self.assertTrue(b.getControl('Enable Twitter', index=0).selected)
         self.assertTrue(b.getControl('Enable Twitter Ressort').selected)
+        self.assertTrue(b.getControl('Enable Twitter Print').selected)
         self.assertTrue(b.getControl('Enable Facebook', index=0).selected)
         self.assertTrue(b.getControl('Enable mobile push').selected)
 
         b.getControl('Enable Twitter', index=0).selected = False
         b.getControl('Enable Twitter Ressort').selected = False
+        b.getControl('Enable Twitter Print').selected = False
         b.getControl('Enable Facebook', index=0).selected = False
         b.getControl('Enable mobile push').selected = False
         b.getControl('Apply').click()
         article = self.get_article()
         push = zeit.push.interfaces.IPushMessages(article)
-        self.assertEqual(4, len(push.message_config))
+        self.assertEqual(5, len(push.message_config))
         self.assertIn(
             {'type': 'twitter', 'enabled': False, 'account': 'twitter-test'},
             push.message_config)
@@ -92,6 +100,10 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
             {'type': 'twitter', 'enabled': False, 'variant': 'ressort',
              'account': 'twitter_ressort_wissen',
              'override_text': 'additional ressort tweet'},
+            push.message_config)
+        self.assertIn(
+            {'type': 'twitter', 'enabled': False, 'account': 'twitter-print',
+             'override_text': 'additional print tweet'},
             push.message_config)
         self.assertIn(
             {'type': 'facebook', 'enabled': False, 'account': 'fb-test',
@@ -106,6 +118,7 @@ class SocialFormTest(zeit.cms.testing.BrowserTestCase):
         self.open_form()
         self.assertFalse(b.getControl('Enable Twitter', index=0).selected)
         self.assertFalse(b.getControl('Enable Twitter Ressort').selected)
+        self.assertFalse(b.getControl('Enable Twitter Print').selected)
         self.assertFalse(b.getControl('Enable Facebook', index=0).selected)
         self.assertFalse(b.getControl('Enable mobile push').selected)
 

--- a/src/zeit/push/interfaces.py
+++ b/src/zeit/push/interfaces.py
@@ -163,16 +163,27 @@ class TwitterAccountSource(zeit.cms.content.sources.XMLSource):
         def MAIN_ACCOUNT(self):
             return self.factory.main_account()
 
+        @property
+        def PRINT_ACCOUNT(self):
+            return self.factory.print_account()
+
     @classmethod
     def main_account(cls):
         config = zope.app.appsetup.product.getProductConfiguration(
             cls.product_configuration)
         return config['twitter-main-account']
 
+    @classmethod
+    def print_account(cls):
+        config = zope.app.appsetup.product.getProductConfiguration(
+            cls.product_configuration)
+        return config['twitter-print-account']
+
     def isAvailable(self, node, context):
         return (
             super(TwitterAccountSource, self).isAvailable(node, context) and
-            node.get('name') != self.main_account())
+            node.get('name') not in [
+                self.main_account(), self.print_account()])
 
     def access_token(self, value):
         tree = self._get_tree()
@@ -329,6 +340,11 @@ class IAccountData(zope.interface.Interface):
         title=_('Additional Twitter'),
         source=twitterAccountSource,
         required=False)
+    twitter_print_text = zope.schema.Text(
+        title=_('Print Tweet'),
+        required=False,
+        max_length=256)
+    twitter_print_enabled = zope.schema.Bool(title=_('Enable Twitter Print'))
 
     mobile_title = zope.schema.TextLine(
         title=_('Mobile title'), required=False)

--- a/src/zeit/push/message.py
+++ b/src/zeit/push/message.py
@@ -266,6 +266,32 @@ class AccountData(grok.Adapter):
         return {}
 
     @property
+    def twitter_print_enabled(self):
+        source = zeit.push.interfaces.twitterAccountSource(None)
+        service = self.push.get(type='twitter', account=source.PRINT_ACCOUNT)
+        return service and service.get('enabled')
+
+    @twitter_print_enabled.setter
+    def twitter_print_enabled(self, value):
+        source = zeit.push.interfaces.twitterAccountSource(None)
+        self.push.set(dict(
+            type='twitter', account=source.PRINT_ACCOUNT),
+            enabled=value)
+
+    @property
+    def twitter_print_text(self):
+        source = zeit.push.interfaces.twitterAccountSource(None)
+        service = self.push.get(type='twitter', account=source.PRINT_ACCOUNT)
+        return service and service.get('override_text')
+
+    @twitter_print_text.setter
+    def twitter_print_text(self, value):
+        source = zeit.push.interfaces.twitterAccountSource(None)
+        self.push.set(
+            dict(type='twitter', account=source.PRINT_ACCOUNT),
+            override_text=value)
+
+    @property
     def mobile_enabled(self):
         service = self._mobile_service
         return service and service.get('enabled')

--- a/src/zeit/push/testing.py
+++ b/src/zeit/push/testing.py
@@ -32,6 +32,7 @@ product_config = """\
 <product-config zeit.push>
   twitter-accounts file://{fixtures}/twitter-accounts.xml
   twitter-main-account twitter-test
+  twitter-print-account twitter-print
   facebook-accounts file://{fixtures}/facebook-accounts.xml
   facebook-main-account fb-test
   facebook-magazin-account fb-magazin

--- a/src/zeit/push/tests/fixtures/twitter-accounts.xml
+++ b/src/zeit/push/tests/fixtures/twitter-accounts.xml
@@ -1,5 +1,6 @@
 <twitter-accounts>
   <account name="twitter-test" token="2512010726-zzomC6jSp453N4Hsn7Ji3hYirt0a35sV0uL8Dy3" secret="DiVzrTRkh5YJCJztiqCCwXBIzGlqa1q7Zi1bDB8aASYOj">Gocept Testaccount</account>
+  <account name="twitter-print" token="None" secret="None">DIEZEIT</account>
   <account name="twitter_ressort_wissen" token="None" secret="None">Wissen</account>
   <account name="twitter_ressort_politik" token="None" secret="None">Politik</account>
 </twitter-accounts>


### PR DESCRIPTION
* zeit.locales hab ich auf master gepusht
* Konfiguration ist aufm [vivi-deployment master](https://github.com/ZeitOnline/vivi-deployment/commit/67c9434bde90d5bc8719a39486bf984f2317ef5f)
* Das Token für den `@DIEZEIT` Account ist in [production](http://cms-backend.zeit.de:9000/cms/forms/twitter-accounts.xml) eingetragen.